### PR TITLE
[java] distinct "object with this id already exists" exception and "plasma store run out of memory" exception

### DIFF
--- a/cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc
+++ b/cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc
@@ -102,13 +102,13 @@ JNIEXPORT jobject JNICALL Java_org_apache_arrow_plasma_PlasmaClientJNI_create(
   std::shared_ptr<Buffer> data;
   Status s = client->Create(oid, size, md, md_size, &data);
   if (s.IsPlasmaObjectExists()) {
-    jclass Exception = env->FindClass("java/lang/Exception");
+    jclass Exception = env->FindClass("org/apache/arrow/plasma/exceptions/DuplicateObjectException");
     env->ThrowNew(Exception,
                   "An object with this ID already exists in the plasma store.");
     return nullptr;
   }
   if (s.IsPlasmaStoreFull()) {
-    jclass Exception = env->FindClass("java/lang/Exception");
+    jclass Exception = env->FindClass("org/apache/arrow/plasma/exceptions/PlasmaOutOfMemoryException");
     env->ThrowNew(Exception,
                   "The plasma store ran out of memory and could not create this object.");
     return nullptr;

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -46,19 +46,19 @@ public class PlasmaClient implements ObjectStoreLink {
 
   // interface methods --------------------
 
+  /**
+   * don't catch exception, exception dealt with in raylet
+   * @param objectId The object ID of the value to be put.
+   * @param value The value to put in the object store.
+   * @param metadata encodes whatever metadata the user wishes to encode.
+   *
+   */
   @Override
   public void put(byte[] objectId, byte[] value, byte[] metadata) {
-    ByteBuffer buf = null;
-    try {
-      buf = PlasmaClientJNI.create(conn, objectId, value.length, metadata);
-    } catch (Exception e) {
-      System.err.println("ObjectId " + objectId + " error at PlasmaClient put");
-      e.printStackTrace();
-    }
+    ByteBuffer buf = PlasmaClientJNI.create(conn, objectId, value.length, metadata);
     if (buf == null) {
       return;
     }
-
     buf.put(value);
     PlasmaClientJNI.seal(conn, objectId);
     PlasmaClientJNI.release(conn, objectId);

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/DuplicateObjectException.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/DuplicateObjectException.java
@@ -1,0 +1,12 @@
+package org.apache.arrow.plasma.exceptions;
+
+public class DuplicateObjectException extends Exception {
+
+  public DuplicateObjectException (String msg) {
+    super(msg);
+  }
+
+  public DuplicateObjectException (String msg, Throwable t) {
+    super(msg, t);
+  }
+}

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaOutOfMemoryException.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaOutOfMemoryException.java
@@ -1,0 +1,13 @@
+package org.apache.arrow.plasma.exceptions;
+
+public class PlasmaOutOfMemoryException extends Exception {
+
+  public PlasmaOutOfMemoryException (String msg) {
+    super(msg);
+  }
+
+  public PlasmaOutOfMemoryException (String msg, Throwable t) {
+    super(msg, t);
+  }
+
+}


### PR DESCRIPTION
@guoyuhong please help review

when ray puts an object in plasma store, there are 2 exceptions may be threw, one is "An object with this ID already exists in the plasma store" and the other is "The plasma store ran out of memory and could not create this object", raylet need to deal with these 2 exceptions seperately. So they can't all be java.lang.Exception class.

